### PR TITLE
TXMNT-366 Use ConfigFactory instead of MDC to read config for app nam…

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -45,7 +45,9 @@ private object AppDependencies {
     "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.1",
     "commons-io" % "commons-io" % "2.4",
     "ch.qos.logback" % "logback-core" % "1.1.7",
-    "ch.qos.logback" % "logback-classic" % "1.1.7"
+    "ch.qos.logback" % "logback-classic" % "1.1.7",
+    "com.typesafe" % "config" % "1.3.1"
+
   )
 
   def apply() = compile


### PR DESCRIPTION
…e and date format.

play-json-logger has a problem with getting the appname/date format from config when the app name hasn't (or never will be) started during integration/unit test.

Instead we plan to move people to use an updated logback-json-logger which uses ConfigFactory to read config.